### PR TITLE
Added /usr/lib/Leap to Libraries search path

### DIFF
--- a/FindLeap.cmake
+++ b/FindLeap.cmake
@@ -27,6 +27,7 @@ IF(UNIX)
         /opt/include INTERNAL)
     SET(LEAP_LIBRARY_SEARCH_DIRS
         /usr/lib
+	/usr/lib/Leap
         /usr/lib64
         /usr/local/lib
         /usr/local/lib64


### PR DESCRIPTION
Leap SDK from AUR installs the leap libraries in /usr/lib/Leap.
